### PR TITLE
Fix pkgconfig can't find gio-2.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,22 @@ set -ex
 # get meson to find pkg-config when cross compiling
 export PKG_CONFIG=$BUILD_PREFIX/bin/pkg-config
 
+# Ensure pkg-config can find host dependencies
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig:$PKG_CONFIG_PATH"
+
+# Additional paths that might contain gio-2.0.pc
+export PKG_CONFIG_PATH="$PREFIX/lib64/pkgconfig:$PKG_CONFIG_PATH"
+
+# Debug: Check if gio-2.0 can be found
+echo "Checking for gio-2.0 pkg-config file..."
+echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
+$PKG_CONFIG --exists gio-2.0 && echo "gio-2.0 found" || echo "gio-2.0 NOT found"
+$PKG_CONFIG --modversion gio-2.0 2>/dev/null || echo "Could not get gio-2.0 version"
+
+# List available .pc files to help debug
+echo "Available .pc files in pkg-config paths:"
+find $PREFIX -name "*.pc" -path "*/pkgconfig/*" | grep -E "(gio|glib)" | head -10
+
 meson_config_args=(
   --wrap-mode=nofallback
   --backend=ninja


### PR DESCRIPTION
Fix can't find gio-2.0 dependency error.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
